### PR TITLE
Hijack policy view model

### DIFF
--- a/KidsSaveOcean.xcodeproj/project.pbxproj
+++ b/KidsSaveOcean.xcodeproj/project.pbxproj
@@ -20,6 +20,12 @@
 		163D20362170F12200069294 /* HomeScoreTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163D20352170F12200069294 /* HomeScoreTableViewCell.swift */; };
 		163F239F20F694FF00022B38 /* KSOStartPageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163F239E20F694FE00022B38 /* KSOStartPageViewController.swift */; };
 		163F23A120F7FC1C00022B38 /* UIButton+Extentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 163F23A020F7FC1C00022B38 /* UIButton+Extentions.swift */; };
+		164D7302234B4BA00080ACB7 /* HijackPoliciesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164D7301234B4BA00080ACB7 /* HijackPoliciesViewModel.swift */; };
+		164D7304234B548D0080ACB7 /* HijackPLocationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164D7303234B548D0080ACB7 /* HijackPLocationViewModel.swift */; };
+		164D7306234B9E6A0080ACB7 /* HijackPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164D7305234B9E6A0080ACB7 /* HijackPolicy.swift */; };
+		164D7308234BA1FB0080ACB7 /* HijackLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164D7307234BA1FB0080ACB7 /* HijackLocation.swift */; };
+		164D730F234BA39D0080ACB7 /* Campaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164D730E234BA39D0080ACB7 /* Campaign.swift */; };
+		164D7311234BA56F0080ACB7 /* CampaignViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164D7310234BA56F0080ACB7 /* CampaignViewModel.swift */; };
 		164E6E2221EB785A00DEB99C /* DashboardTopIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 164E6E2121EB785A00DEB99C /* DashboardTopIcon.swift */; };
 		164F14EA21F68BD400823FF3 /* Onboarding.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 164F14E921F68BD400823FF3 /* Onboarding.storyboard */; };
 		164F14F521F6914D00823FF3 /* HomeScoreTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 164F14F321F6914D00823FF3 /* HomeScoreTableViewCell.xib */; };
@@ -122,6 +128,12 @@
 		163D20352170F12200069294 /* HomeScoreTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeScoreTableViewCell.swift; sourceTree = "<group>"; };
 		163F239E20F694FE00022B38 /* KSOStartPageViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KSOStartPageViewController.swift; sourceTree = "<group>"; };
 		163F23A020F7FC1C00022B38 /* UIButton+Extentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Extentions.swift"; sourceTree = "<group>"; };
+		164D7301234B4BA00080ACB7 /* HijackPoliciesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HijackPoliciesViewModel.swift; sourceTree = "<group>"; };
+		164D7303234B548D0080ACB7 /* HijackPLocationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HijackPLocationViewModel.swift; sourceTree = "<group>"; };
+		164D7305234B9E6A0080ACB7 /* HijackPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HijackPolicy.swift; sourceTree = "<group>"; };
+		164D7307234BA1FB0080ACB7 /* HijackLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HijackLocation.swift; sourceTree = "<group>"; };
+		164D730E234BA39D0080ACB7 /* Campaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Campaign.swift; sourceTree = "<group>"; };
+		164D7310234BA56F0080ACB7 /* CampaignViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CampaignViewModel.swift; sourceTree = "<group>"; };
 		164E6E2121EB785A00DEB99C /* DashboardTopIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTopIcon.swift; sourceTree = "<group>"; };
 		164F14E921F68BD400823FF3 /* Onboarding.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Onboarding.storyboard; sourceTree = "<group>"; };
 		164F14F321F6914D00823FF3 /* HomeScoreTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = HomeScoreTableViewCell.xib; sourceTree = "<group>"; };
@@ -241,6 +253,43 @@
 				164F14ED21F690CA00823FF3 /* Home TableView Cells */,
 			);
 			path = Home;
+			sourceTree = "<group>";
+		};
+		164D7300234B4B820080ACB7 /* HijackPolicy */ = {
+			isa = PBXGroup;
+			children = (
+				164D730B234BA25D0080ACB7 /* Campaign */,
+				164D7309234BA2440080ACB7 /* Policies */,
+				164D730A234BA24E0080ACB7 /* Location */,
+			);
+			path = HijackPolicy;
+			sourceTree = "<group>";
+		};
+		164D7309234BA2440080ACB7 /* Policies */ = {
+			isa = PBXGroup;
+			children = (
+				164D7301234B4BA00080ACB7 /* HijackPoliciesViewModel.swift */,
+				164D7305234B9E6A0080ACB7 /* HijackPolicy.swift */,
+			);
+			path = Policies;
+			sourceTree = "<group>";
+		};
+		164D730A234BA24E0080ACB7 /* Location */ = {
+			isa = PBXGroup;
+			children = (
+				164D7303234B548D0080ACB7 /* HijackPLocationViewModel.swift */,
+				164D7307234BA1FB0080ACB7 /* HijackLocation.swift */,
+			);
+			path = Location;
+			sourceTree = "<group>";
+		};
+		164D730B234BA25D0080ACB7 /* Campaign */ = {
+			isa = PBXGroup;
+			children = (
+				164D7310234BA56F0080ACB7 /* CampaignViewModel.swift */,
+				164D730E234BA39D0080ACB7 /* Campaign.swift */,
+			);
+			path = Campaign;
 			sourceTree = "<group>";
 		};
 		164D8B0D20C6BC170067EE52 /* Resources */ = {
@@ -437,6 +486,7 @@
 		16CF5A2820AF1E5600C4E57E /* ViewModel */ = {
 			isa = PBXGroup;
 			children = (
+				164D7300234B4B820080ACB7 /* HijackPolicy */,
 				16BA0A39229027B500E36F25 /* UserId */,
 				7C0B1CD522232E9C0033F251 /* CountriesService */,
 				16ED9DA920C343DB005BF4E1 /* KSOStaticDataStructures.swift */,
@@ -885,11 +935,14 @@
 				16BA0A3C229027F100E36F25 /* UserViewModel.swift in Sources */,
 				7C00FFBA21185B7000320309 /* CountryContactsViewController.swift in Sources */,
 				7CB51D38233A901D0014094C /* StepsTableViewCell.swift in Sources */,
+				164D7308234BA1FB0080ACB7 /* HijackLocation.swift in Sources */,
+				164D7306234B9E6A0080ACB7 /* HijackPolicy.swift in Sources */,
 				161A0C1222B291DC0047DD40 /* LocationService.swift in Sources */,
 				16D4C28322C3FDBE006DBC64 /* NotificationProtocol.swift in Sources */,
 				16D4C28522C3FE10006DBC64 /* NotificationBadgeProtocol.swift in Sources */,
 				7C98916B2331285100400CC5 /* MultiplympactViewController.swift in Sources */,
 				7CFF7BE22339455E00C7081E /* EnvironmentTableViewCell.swift in Sources */,
+				164D7302234B4BA00080ACB7 /* HijackPoliciesViewModel.swift in Sources */,
 				7C4BAB9E211C94B00038BAF2 /* CountryContact.swift in Sources */,
 				1679C90822E270B700BC1A89 /* NotificationTarget.swift in Sources */,
 				7C9891632331264C00400CC5 /* YouthInitiativeProcessViewController.swift in Sources */,
@@ -899,6 +952,7 @@
 				163416FE215976E200C98646 /* UserTypeTableViewController.swift in Sources */,
 				946847D92139E299007A1158 /* KSOCustomMapPin.swift in Sources */,
 				7C7BBAC521B864B100C48D4E /* LetterTrackerViewController.swift in Sources */,
+				164D730F234BA39D0080ACB7 /* Campaign.swift in Sources */,
 				163D20362170F12200069294 /* HomeScoreTableViewCell.swift in Sources */,
 				16768111215AD41E00EE4E1F /* HomeTableViewController.swift in Sources */,
 				7C2B9A6F21188EEB00977E21 /* CountryContactsViewModel.swift in Sources */,
@@ -909,6 +963,7 @@
 				945A089120F643EB006ED13D /* MapViewController.swift in Sources */,
 				16D4C27E22C157AD006DBC64 /* Instantiatable.swift in Sources */,
 				16BA0A3E2290281A00E36F25 /* User.swift in Sources */,
+				164D7304234B548D0080ACB7 /* HijackPLocationViewModel.swift in Sources */,
 				7C9891652331274900400CC5 /* Follow7StepsViewController.swift in Sources */,
 				C55E0700214EEAB9009B7BD6 /* CGFloat+Extentions.swift in Sources */,
 				16ED9DAA20C343DB005BF4E1 /* KSOStaticDataStructures.swift in Sources */,
@@ -931,6 +986,7 @@
 				7C312FD82118DFE5008CEDDA /* ContactDetailsViewController.swift in Sources */,
 				C55E0703214EF0ED009B7BD6 /* KSOMapTop10TableViewCell.swift in Sources */,
 				165FBFA220DB565500DB556F /* UIColor+Extentions.swift in Sources */,
+				164D7311234BA56F0080ACB7 /* CampaignViewModel.swift in Sources */,
 				16768113215AD71100EE4E1F /* HomeTableViewCell.swift in Sources */,
 				7C989167233127A800400CC5 /* VoteNowViewController.swift in Sources */,
 				162572D422E37DEF00A702C4 /* UserDefaultsHelper.swift in Sources */,

--- a/KidsSaveOcean/AppDelegate.swift
+++ b/KidsSaveOcean/AppDelegate.swift
@@ -22,6 +22,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         KSOAuthorization.anonymousAuthorization {
             UserViewModel.shared()
             CountriesService.shared().setup()
+            HijackPLocationViewModel.shared().setup()
+            HijackPoliciesViewModel.shared().setup()
+            CampaignViewModel.shared().setup()
         }
         
         // MARK: - Check if user already opened the tutorial screen

--- a/KidsSaveOcean/ViewModel/HijackPolicy/Campaign/Campaign.swift
+++ b/KidsSaveOcean/ViewModel/HijackPolicy/Campaign/Campaign.swift
@@ -1,0 +1,37 @@
+//
+//  Campaign.swift
+//  KidsSaveOcean
+//
+//  Created by Maria Soboleva on 10/7/19.
+//  Copyright © 2019 KidsSaveOcean. All rights reserved.
+//
+
+import Foundation
+
+struct Campaign {
+    let id: String
+    let hijack_policy: String
+    let live: Bool
+    let location_id: String
+    var signatures_collected: Int
+    var signatures_pledged: Int
+    let signatures_required: Int
+    
+    init(id: String, hijack_policy: String, live: Bool, location_id: String, signatures_collected: Int, signatures_pledged: Int, signatures_required: Int) {
+        self.id = id
+        self.hijack_policy = hijack_policy
+        self.live = live
+        self.location_id = location_id
+        self.signatures_collected = signatures_collected
+        self.signatures_pledged = signatures_pledged
+        self.signatures_required = signatures_required
+    }
+    
+    mutating func updateSignagureCollected(to value: Int) {
+        self.signatures_collected = value
+    }
+    
+    mutating func updateSignagurePledged(to value: Int) {
+        self.signatures_pledged = value
+    }
+}

--- a/KidsSaveOcean/ViewModel/HijackPolicy/Campaign/CampaignViewModel.swift
+++ b/KidsSaveOcean/ViewModel/HijackPolicy/Campaign/CampaignViewModel.swift
@@ -1,0 +1,89 @@
+//
+//  CampaignViewModel.swift
+//  KidsSaveOcean
+//
+//  Created by Maria Soboleva on 10/7/19.
+//  Copyright © 2019 KidsSaveOcean. All rights reserved.
+//
+
+import Foundation
+import Firebase
+
+class CampaignViewModel {
+    static var nodeName = "CAMPAIGNS"
+    var databaseReferenece: DatabaseReference = Database.database().reference().child(nodeName)
+    var campaigns = [Campaign]()
+    
+    private static var sharedCampaignsViewModel: CampaignViewModel = {
+        let viewModel = CampaignViewModel()
+        return viewModel
+    }()
+
+    class func shared() -> CampaignViewModel {
+        return sharedCampaignsViewModel
+    }
+    
+    func setup() {
+        fetchCampaigns(nil)
+    }
+    
+    // swiftlint:disable cyclomatic_complexity
+    func fetchCampaigns(_ completion: (() -> Void)?) {
+
+        campaigns.removeAll()
+        
+        databaseReferenece.observeSingleEvent(of: .value, with: { (snapshot) in
+            guard let snapshotValue = snapshot.value as? NSDictionary else {
+                return
+            }
+
+            for campaign in snapshotValue {
+
+                guard let id = campaign.key as? String else {
+                    continue
+                }
+                
+                guard let value = campaign.value as? NSDictionary else {
+                    continue
+                }
+
+                guard let policy = value["hijack_policy"] as? String else {
+                    continue
+                }
+                guard let live = value["live"] as? Bool else {
+                    continue
+                }
+                guard let location = value["location_id"] as? String else {
+                    continue
+                }
+                guard let sign_collected = value["signatures_collected"] as? Int else {
+                    continue
+                }
+                guard let sign_pledged = value["signatures_pledged"] as? Int else {
+                    continue
+                }
+                guard let sigh_required = value["signatures_required"] as? Int else {
+                    continue
+                }
+                
+                let campaignObj = Campaign(id: id, hijack_policy: policy, live: live, location_id: location, signatures_collected: sign_collected, signatures_pledged: sign_pledged, signatures_required: sigh_required)
+                
+                self.campaigns.append(campaignObj)
+            }
+    
+            if completion != nil {
+                completion!()
+            }
+        })
+    }
+    
+    func updatePlannedSignatures(campaign: Campaign, value: Int) {
+        Database.database().reference().child(CampaignViewModel.nodeName).child(campaign.id).child("signatures_pledged").setValue(value)
+            setup()
+    }
+    
+    func updateCollectedSignatures(campaign: Campaign, value: Int) {
+        Database.database().reference().child(CampaignViewModel.nodeName).child(campaign.id).child("signatures_collected").setValue(value)
+            setup()
+   }
+}

--- a/KidsSaveOcean/ViewModel/HijackPolicy/Location/HijackLocation.swift
+++ b/KidsSaveOcean/ViewModel/HijackPolicy/Location/HijackLocation.swift
@@ -1,0 +1,19 @@
+//
+//  HijackLocation.swift
+//  KidsSaveOcean
+//
+//  Created by Maria Soboleva on 10/7/19.
+//  Copyright © 2019 KidsSaveOcean. All rights reserved.
+//
+
+import Foundation
+
+struct HijackLocation {
+    let id: String
+    let location: String
+    
+    init(id: String, location: String) {
+        self.id = id
+        self.location = location
+    }
+}

--- a/KidsSaveOcean/ViewModel/HijackPolicy/Location/HijackPLocationViewModel.swift
+++ b/KidsSaveOcean/ViewModel/HijackPolicy/Location/HijackPLocationViewModel.swift
@@ -1,0 +1,62 @@
+//
+//  HijackPolicyLocationViewModel.swift
+//  KidsSaveOcean
+//
+//  Created by Maria Soboleva on 10/7/19.
+//  Copyright © 2019 KidsSaveOcean. All rights reserved.
+//
+
+import Foundation
+import Firebase
+
+class HijackPLocationViewModel {
+    
+    var databaseReferenece: DatabaseReference = Database.database().reference().child("HIJACK_POLICY_LOCATIONS")
+    var hidjackPLocations = [HijackLocation]()
+    
+    private static var sharedHijackPLocationViewModel: HijackPLocationViewModel = {
+        let viewModel = HijackPLocationViewModel()
+        return viewModel
+    }()
+
+    class func shared() -> HijackPLocationViewModel {
+        return sharedHijackPLocationViewModel
+    }
+    
+    func setup() {
+        fetchPolicyLocations(nil)
+    }
+    
+    func fetchPolicyLocations(_ completion: (() -> Void)?) {
+
+        hidjackPLocations.removeAll()
+        
+        databaseReferenece.observeSingleEvent(of: .value, with: { (snapshot) in
+            guard let snapshotValue = snapshot.value as? NSDictionary else {
+                return
+            }
+
+            for location in snapshotValue {
+
+                guard let id = location.key as? String else {
+                    continue
+                }
+                
+                guard let value = location.value as? NSDictionary else {
+                    continue
+                }
+
+                guard let location = value["location"] as? String else {
+                    continue
+                }
+                
+                let policyLocation = HijackLocation(id: id, location: location)
+                self.hidjackPLocations.append(policyLocation)
+            }
+    
+            if completion != nil {
+                completion!()
+            }
+        })
+    }
+}

--- a/KidsSaveOcean/ViewModel/HijackPolicy/Policies/HijackPoliciesViewModel.swift
+++ b/KidsSaveOcean/ViewModel/HijackPolicy/Policies/HijackPoliciesViewModel.swift
@@ -1,0 +1,76 @@
+//
+//  HijackPolicyViewModel.swift
+//  KidsSaveOcean
+//
+//  Created by Maria Soboleva on 10/7/19.
+//  Copyright © 2019 KidsSaveOcean. All rights reserved.
+//
+
+import Foundation
+import Firebase
+
+class HijackPoliciesViewModel {
+    
+    static var nodeName = "HIJACK_POLICIES"
+    var databaseReferenece: DatabaseReference = Database.database().reference().child(nodeName)
+    var hidjackPolicies = [HijackPolicy]()
+    
+    private static var sharedHijackPolicyViewModel: HijackPoliciesViewModel = {
+        let viewModel = HijackPoliciesViewModel()
+        return viewModel
+    }()
+
+    class func shared() -> HijackPoliciesViewModel {
+        return sharedHijackPolicyViewModel
+    }
+    
+    func setup() {
+        fetchPolicies(nil)
+    }
+    
+    func fetchPolicies(_ completion: (() -> Void)?) {
+
+        hidjackPolicies.removeAll()
+        
+        databaseReferenece.observeSingleEvent(of: .value, with: { (snapshot) in
+            guard let snapshotValue = snapshot.value as? NSDictionary else {
+                return
+            }
+
+            for policies in snapshotValue {
+
+                guard let id = policies.key as? String else {
+                    continue
+                }
+                
+                guard let value = policies.value as? NSDictionary else {
+                    continue
+                }
+
+                guard let description = value["description"] as? String else {
+                    continue
+                }
+                
+                guard let summary = value["summary"] as? String else {
+                    continue
+                }
+                
+                guard let votes = value["votes"] as? Int else {
+                    continue
+                }
+                
+                let policy = HijackPolicy(id: id, description: description, summary: summary, votes: votes)
+                self.hidjackPolicies.append(policy)
+            }
+    
+            if completion != nil {
+                completion!()
+            }
+        })
+    }
+    
+    func updateVotes(policy: HijackPolicy, value: Int) {
+         Database.database().reference().child(HijackPoliciesViewModel.nodeName).child(policy.id).child("votes").setValue(value)
+             setup()
+    }
+}

--- a/KidsSaveOcean/ViewModel/HijackPolicy/Policies/HijackPolicy.swift
+++ b/KidsSaveOcean/ViewModel/HijackPolicy/Policies/HijackPolicy.swift
@@ -1,0 +1,27 @@
+//
+//  HijackPolicy.swift
+//  KidsSaveOcean
+//
+//  Created by Maria Soboleva on 10/7/19.
+//  Copyright © 2019 KidsSaveOcean. All rights reserved.
+//
+
+import Foundation
+
+struct HijackPolicy {
+    let id: String
+    let description: String
+    let summary: String
+    var votes: Int
+    
+    init(id: String, description: String, summary: String, votes: Int? ) {
+        self.id = id
+        self.description = description
+        self.summary = summary
+        self.votes = votes ?? 0
+    }
+    
+    mutating func updateVotes(to value: Int) {
+        self.votes = value
+    }
+}

--- a/KidsSaveOcean/ViewModel/UserId/UserViewModel.swift
+++ b/KidsSaveOcean/ViewModel/UserId/UserViewModel.swift
@@ -333,11 +333,6 @@ class UserViewModel {
     }
 
     func saveUser() {
-        var p = HijackPoliciesViewModel.shared().hidjackPolicies[0]
-        p.updateVotes(to: 2)
-        print(p)
-        HijackPoliciesViewModel.shared().updateVotes(policy: p, value: 3)
-        
         parametersDisctionary[userTypeKey] = self.user_type.rawValue
         databaseReferenece?.setValue(parametersDisctionary) { (error: Error?, _: DatabaseReference) in
             if error != nil {


### PR DESCRIPTION
Added view models for getting data from Firebase nodes: 

Added view models for nodes:
HijackPLocationViewModel for HIJACK_POLICY_LOCATION
HijackPoliciesViewModel for HIJACK_POLICY
CampaignViewModel for CAMPAIGN
Also added campaign and hijack_policy_selected for UserModelView.

How to use it (for example): 

// array with hijack policies:
for policy in HijackPoliciesViewModel.shared().hidjackPolicies {
       print("\n\\(policy)")
}
 
// array with hijack policy locations
 for location in HijackPLocationViewModel.shared().hidjackPLocations {
        print("\n\\(location)")
  }
 
// array with campaigns
for campaign in CampaignViewModel.shared().campaigns {
         print("\n\\(campaign)")
} 

// update vote in hijack policy:
var p = HijackPoliciesViewModel.shared().hidjackPolicies[0] // or whatever by user's choice
HijackPoliciesViewModel.shared().updateVotes(policy: p, value: 3)

// get/set user's hijack_policy_selected
UserViewModel.shared().hijack_policy_selected = "hijack_policy_01" 

// get/set user's planned and collected signatures:
UserViewModel.shared().campain = ["campaign_id": "campaign_01",
                                        "signatures_collected": 5,
                                        "signatures_pledged": 150 ]

